### PR TITLE
👌 IMPROVE: since/until: assume git reference, fallback to datetime

### DIFF
--- a/github_activity/cli.py
+++ b/github_activity/cli.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from .github_activity import generate_activity_md
+from .git import _git_installed_check
 
 DESCRIPTION = "Generate a markdown changelog of GitHub activity within a date window."
 parser = argparse.ArgumentParser(description=DESCRIPTION)
@@ -83,6 +84,10 @@ parser.add_argument(
 
 
 def main():
+    if not _git_installed_check():
+        print("git is required to run github-activity")
+        sys.exit(1)
+
     args = parser.parse_args(sys.argv[1:])
     tags = args.tags.split(",") if args.tags is not None else args.tags
     md = generate_activity_md(

--- a/github_activity/git.py
+++ b/github_activity/git.py
@@ -1,0 +1,18 @@
+import subprocess
+
+def _git_installed_check():
+    cmd = ["git", "--help"]
+    try:
+        subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _valid_git_reference_check(git_ref):
+    cmd = ["git", "rev-parse", "--verify", git_ref]
+    try:
+        subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except subprocess.CalledProcessError:
+        return False

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     name="github_activity",
     version=version,
     include_package_data=True,
-    python_requires=">=3.4",
+    python_requires=">=3.6",
     author="Chris Holdgraf",
     author_email="choldgraf@berkeley.edu",
     url="https://jupyter.org/",


### PR DESCRIPTION
Closes #15

## Review notes
_Key point_
I realize that I've made a check against the local folder now if the provided string is a git reference or not, and then to fallback assuming it is a date. But, now a command like the one below will do the wrong things if not located inside a local jupyterhub/configurable-http-proxy git clone, or if its an very outdated git clone without knowledge of the reference which may be available upstream but not locally. Hmmm....

```
github-activity jupyterhub/configurable-http-proxy --kind pr --since 4.1.0
```

_Other points_
- I've made this project depend on the `git` cli, and a check is added to fail early if its missing.
- No test is added.
- I bumped the python requirement to py36 to avoid issues with the subprocess library that I know have an API that have changed a lot. Py34 and Py35 are no longer supported by Python.