### PR TITLE
[FIX,TST] resolve refs when not run from a repo

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -486,12 +486,19 @@ def _get_datetime_and_type(org, repo, datetime_or_git_ref):
         dt = datetime.datetime.now().astimezone(pytz.utc)
         return (dt, False)
 
-    if _valid_git_reference_check(datetime_or_git_ref):
+    try:
         dt = _get_datetime_from_git_ref(org, repo, datetime_or_git_ref)
         return (dt, True)
-    else:
-        dt = dateutil.parser.parse(datetime_or_git_ref)
-        return (dt, False)
+    except Exception as ref_error:
+        try:
+            dt = dateutil.parser.parse(datetime_or_git_ref)
+            return (dt, False)
+        except Exception as datetime_error:
+            raise ValueError(
+                "{0} not found as a ref or valid date format".format(
+                    datetime_or_git_ref
+                )
+            )
 
 
 def _get_datetime_from_git_ref(org, repo, ref):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,8 @@ def test_cli(tmpdir, file_regression):
     path_tmp = Path(tmpdir)
     path_output = path_tmp.joinpath("out.md")
 
-    url = "https://github.com/choldgraf/github-activity"
-    org, repo = ("choldgraf", "github-activity")
+    url = "https://github.com/executablebooks/github-activity"
+    org, repo = ("executablebooks", "github-activity")
 
     # CLI with URL
     cmd = f"github-activity {url} -s 2019-09-01 -u 2019-11-01 -o {path_output}"

--- a/tests/test_cli/test_cli.md
+++ b/tests/test_cli/test_cli.md
@@ -1,18 +1,18 @@
 # master@{2019-09-01}...master@{2019-11-01}
-([full changelog](https://github.com/choldgraf/github-activity/compare/479cc4b2f5504945021e3c4ee84818a10fabf810...ed7f1ed78b523c6b9fe6b3ac29e834087e299296))
+([full changelog](https://github.com/executablebooks/github-activity/compare/479cc4b2f5504945021e3c4ee84818a10fabf810...ed7f1ed78b523c6b9fe6b3ac29e834087e299296))
 
 
 ## Merged PRs
-* defining contributions [#14](https://github.com/choldgraf/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
-* updating CLI for new tags [#12](https://github.com/choldgraf/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
-* fixing link to changelog with refs [#11](https://github.com/choldgraf/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
-* adding contributors list [#10](https://github.com/choldgraf/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
-* some improvements to `since` and opened issues list [#8](https://github.com/choldgraf/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
-* Support git references etc. [#6](https://github.com/choldgraf/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
-* adding authentication information [#2](https://github.com/choldgraf/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
-* Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/choldgraf/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
+* defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
+* updating CLI for new tags [#12](https://github.com/executablebooks/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
+* fixing link to changelog with refs [#11](https://github.com/executablebooks/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
+* adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
+* some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
+* Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
+* adding authentication information [#2](https://github.com/executablebooks/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
+* Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
 
 ## Contributors to this release
-([GitHub contributors page for this release](https://github.com/choldgraf/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
+([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
 
-[@betatim](https://github.com/search?q=repo%3Acholdgraf%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Acholdgraf%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Acholdgraf%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)
+[@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)


### PR DESCRIPTION
Get the tests passing again (related to #28 since tests aren't run on CI right now)

- test_cli was failing due to the repository transfer to executablebooks. Updating the repo URL in the test and expected output got it passing again
- test_pr_split failed to resolve jupyter-book tags as dates because `_validate_git_ref` assumes the target repo is cloned and up-to-date in the current directory. This is fixed by unconditionally attempting to resolve refs via GitHub API, and falling back on date parsing when that fails for any reason. The result is that repos no longer need to be cloned to collect activity between refs.