### PR TITLE
👌IMPROVE: add blank lines below headings

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -394,11 +394,12 @@ def generate_activity_md(
     changelog_url = f"https://github.com/{org}/{repo}/compare/{since_ref}...{until_ref}"
 
     # Build the Markdown
-    md = [f"# {since}...{until}", f"([full changelog]({changelog_url}))", ""]
+    md = [f"# {since}...{until}", "", f"([full changelog]({changelog_url}))"]
     for kind, info in prs.items():
         if len(info["md"]) > 0:
             md += [""]
             md.append(f"## {info['description']}")
+            md += [""]
             md += info["md"]
 
     # Add a list of author contributions
@@ -411,9 +412,11 @@ def generate_activity_md(
     gh_contributors_link = f"https://github.com/{org}/{repo}/graphs/contributors?from={data.since_dt:%Y-%m-%d}&to={data.until_dt:%Y-%m-%d}&type=c"
     md += [""]
     md += ["## Contributors to this release"]
+    md += [""]
     md += [f"([GitHub contributors page for this release]({gh_contributors_link}))"]
     md += [""]
     md += [contributor_md]
+    md += [""]
     md = "\n".join(md)
     return md
 

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -486,12 +486,19 @@ def _get_datetime_and_type(org, repo, datetime_or_git_ref):
         dt = datetime.datetime.now().astimezone(pytz.utc)
         return (dt, False)
 
-    if _valid_git_reference_check(datetime_or_git_ref):
+    try:
         dt = _get_datetime_from_git_ref(org, repo, datetime_or_git_ref)
         return (dt, True)
-    else:
-        dt = dateutil.parser.parse(datetime_or_git_ref)
-        return (dt, False)
+    except Exception as ref_error:
+        try:
+            dt = dateutil.parser.parse(datetime_or_git_ref)
+            return (dt, False)
+        except Exception as datetime_error:
+            raise ValueError(
+                "{0} not found as a ref or valid date format".format(
+                    datetime_or_git_ref
+                )
+            )
 
 
 def _get_datetime_from_git_ref(org, repo, ref):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,8 @@ def test_cli(tmpdir, file_regression):
     path_tmp = Path(tmpdir)
     path_output = path_tmp.joinpath("out.md")
 
-    url = "https://github.com/choldgraf/github-activity"
-    org, repo = ("choldgraf", "github-activity")
+    url = "https://github.com/executablebooks/github-activity"
+    org, repo = ("executablebooks", "github-activity")
 
     # CLI with URL
     cmd = f"github-activity {url} -s 2019-09-01 -u 2019-11-01 -o {path_output}"

--- a/tests/test_cli/test_cli.md
+++ b/tests/test_cli/test_cli.md
@@ -1,18 +1,18 @@
 # master@{2019-09-01}...master@{2019-11-01}
-([full changelog](https://github.com/choldgraf/github-activity/compare/479cc4b2f5504945021e3c4ee84818a10fabf810...ed7f1ed78b523c6b9fe6b3ac29e834087e299296))
+([full changelog](https://github.com/executablebooks/github-activity/compare/479cc4b2f5504945021e3c4ee84818a10fabf810...ed7f1ed78b523c6b9fe6b3ac29e834087e299296))
 
 
 ## Merged PRs
-* defining contributions [#14](https://github.com/choldgraf/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
-* updating CLI for new tags [#12](https://github.com/choldgraf/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
-* fixing link to changelog with refs [#11](https://github.com/choldgraf/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
-* adding contributors list [#10](https://github.com/choldgraf/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
-* some improvements to `since` and opened issues list [#8](https://github.com/choldgraf/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
-* Support git references etc. [#6](https://github.com/choldgraf/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
-* adding authentication information [#2](https://github.com/choldgraf/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
-* Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/choldgraf/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
+* defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
+* updating CLI for new tags [#12](https://github.com/executablebooks/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
+* fixing link to changelog with refs [#11](https://github.com/executablebooks/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
+* adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
+* some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
+* Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
+* adding authentication information [#2](https://github.com/executablebooks/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
+* Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
 
 ## Contributors to this release
-([GitHub contributors page for this release](https://github.com/choldgraf/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
+([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
 
-[@betatim](https://github.com/search?q=repo%3Acholdgraf%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Acholdgraf%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Acholdgraf%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)
+[@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)

--- a/tests/test_cli/test_cli.md
+++ b/tests/test_cli/test_cli.md
@@ -1,8 +1,9 @@
 # master@{2019-09-01}...master@{2019-11-01}
+
 ([full changelog](https://github.com/executablebooks/github-activity/compare/479cc4b2f5504945021e3c4ee84818a10fabf810...ed7f1ed78b523c6b9fe6b3ac29e834087e299296))
 
-
 ## Merged PRs
+
 * defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
 * updating CLI for new tags [#12](https://github.com/executablebooks/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
 * fixing link to changelog with refs [#11](https://github.com/executablebooks/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
@@ -13,6 +14,7 @@
 * Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
 
 ## Contributors to this release
+
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
 
 [@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)

--- a/tests/test_cli/test_pr_split.md
+++ b/tests/test_cli/test_pr_split.md
@@ -1,22 +1,26 @@
 # v0.7.1...v0.7.3
+
 ([full changelog](https://github.com/executablebooks/jupyter-book/compare/v0.7.1...v0.7.3))
 
-
 ## New features added
+
 * ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/executablebooks/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf))
 
 ## Enhancements made
+
 * 👌 IMPROVE: improving numbered sections [#826](https://github.com/executablebooks/jupyter-book/pull/826) ([@choldgraf](https://github.com/choldgraf))
 * ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/executablebooks/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf))
 * checking for toc modification time [#772](https://github.com/executablebooks/jupyter-book/pull/772) ([@choldgraf](https://github.com/choldgraf))
 * first pass toc directive [#757](https://github.com/executablebooks/jupyter-book/pull/757) ([@choldgraf](https://github.com/choldgraf))
 
 ## Bugs fixed
+
 * Fix typo in content-blocks.md documentation [#811](https://github.com/executablebooks/jupyter-book/pull/811) ([@MaxGhenis](https://github.com/MaxGhenis))
 * [BUG] Using relative instead of absolute links [#747](https://github.com/executablebooks/jupyter-book/pull/747) ([@AakashGfude](https://github.com/AakashGfude))
 * 🐛 FIX: fixing jupytext install/UI links [#737](https://github.com/executablebooks/jupyter-book/pull/737) ([@chrisjsewell](https://github.com/chrisjsewell))
 
 ## Documentation improvements
+
 * 📚 DOC: update gh-pages + ghp-import docs [#814](https://github.com/executablebooks/jupyter-book/pull/814) ([@TomasBeuzen](https://github.com/TomasBeuzen))
 * 📚 DOC: note about licenses [#806](https://github.com/executablebooks/jupyter-book/pull/806) ([@choldgraf](https://github.com/choldgraf))
 * 📖 DOCS: Fix google analytics instructions [#799](https://github.com/executablebooks/jupyter-book/pull/799) ([@tobydriscoll](https://github.com/tobydriscoll))
@@ -27,6 +31,7 @@
 * typo fix [#731](https://github.com/executablebooks/jupyter-book/pull/731) ([@MaxGhenis](https://github.com/MaxGhenis))
 
 ## API and Breaking Changes
+
 * ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/executablebooks/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf))
 * removing config file numbered sections to use toc file instead [#768](https://github.com/executablebooks/jupyter-book/pull/768) ([@choldgraf](https://github.com/choldgraf))
 


### PR DESCRIPTION
follows conventions of markdown formatters such as prettier for more consistent space surrounding section headings.

ensures trailing newline at the end of output as well, which some tools complain about when missing

Officially a style change, but some markdown parsers don't handle headings
without surrounding space (this is unlikely to be an issue in practice, but it was the case in some markdown processors in the Jupyter ecosystem for a while, predating standards like CommonMark).

Builds on #35 to avoid conflicts.