### PR TITLE
🐛 FIX: tags like 'doctor' would trigger 'doc' tag

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -302,7 +302,7 @@ def generate_activity_md(
     for kind, kindmeta in tags_metadata.items():
         # First find the PRs based on tag
         mask = closed_prs["labels"].map(
-            lambda a: any(ii in jj for ii in kindmeta["tags"] for jj in a)
+            lambda a: any(ii == jj for ii in kindmeta["tags"] for jj in a)
         )
         # Now find PRs based on prefix
         mask_pre = closed_prs["title"].map(


### PR DESCRIPTION
I found that the mask used to decide what PRs should be listed under certain categories etc were misbehaving. I found that my custom `ci` tag I added listed PRs that didn't have the `ci` tag, but instead had the `dependencies` tag. The reason was a Python line of code doing `"ci" in "dependencies"` instead of `"ci" == "dependencies"`.

This seems like a bug, since otherwise it would be pointless to include tags like documentation and docs next to doc.

```
    "documentation": {
        "tags": ["documentation", "docs", "doc"],
        "pre": ["DOC", "DOCS"],
        "description": "Documentation improvements",
    },
```
