### PR TITLE
Adding filtering by branch

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,10 @@ github-activity jupyter/notebook -s 6.0.0 -u 6.0.1 -o sample_notebook_activity.m
 
 You can find the [resulting markdown here](sample_notebook_activity).
 
+```{tip}
+For repositories that use multiple branches, it may be necessary to filter PRs by a branch name.  This can be done using the `--branch` parameter in the CLI.   Other git references can be used as well in place of a branch name.
+```
+
 ### Splitting PRs by tags and prefixes
 
 Often you wish to split your PRs into multiple categories so that they are easier

--- a/github_activity/cli.py
+++ b/github_activity/cli.py
@@ -96,6 +96,14 @@ parser.add_argument(
         """
     ),
 )
+parser.add_argument(
+    "--branch",
+    "-b",
+    default=None,
+    help=(
+        """The branch or reference name to filter pull requests by"""
+    ),
+)
 
 
 def main():
@@ -116,6 +124,7 @@ def main():
         include_opened=bool(args.include_opened),
         strip_brackets=bool(args.strip_brackets),
         heading_level=args.heading_level,
+        branch=args.branch
     )
     if not md:
         return

--- a/github_activity/graphql.py
+++ b/github_activity/graphql.py
@@ -64,6 +64,7 @@ gql_template = """\
         mergeCommit {{
           oid
         }}
+        baseRefName
         {comments}
       }}
       ... on Issue {{

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,18 @@ def test_cli(tmpdir, file_regression):
     md = path_output.read_text()
     file_regression.check(md, extension=".md")
 
+    # CLI with default branch
+    cmd = f"github-activity {org}/{repo} -s 2019-09-01 -u 2019-11-01 -o {path_output} -b master"
+    out = run(cmd.split(), check=True)
+    md = path_output.read_text()
+    file_regression.check(md, extension=".md")
+
+    # CLI with non-existent branch
+    cmd = f"github-activity {org}/{repo} -s 2019-09-01 -u 2019-11-01 -o {path_output} -b foo"
+    out = run(cmd.split(), check=True)
+    md = path_output.read_text()
+    assert "Contributors to this release" in md
+    assert "Merged PRs" not in md
 
 def test_pr_split(tmpdir, file_regression):
     """Test that PRs are properly split by tags/prefixes."""


### PR DESCRIPTION
This adds the ability to filter PRs etc via branch name, via a `branch` param.

cc @blink1073 who I think uses multiple branches on JupyterLab, maybe this will be useful?