### PR TITLE
FIX: write status messages to sys.stderr

### DIFF
--- a/github_activity/cache.py
+++ b/github_activity/cache.py
@@ -9,7 +9,7 @@ def _cache_data(query_data, path_cache):
         path_cache = DEFAULT_PATH_CACHE
     path_cache = Path(path_cache)
     if not path_cache.exists():
-        print(f"Creating a new cache at {path_cache}")
+        print(f"Creating a new cache at {path_cache}", file=sys.stderr)
         path_cache.mkdir()
 
     for (org, repo), idata in query_data.groupby(["org", "repo"]):

--- a/github_activity/cli.py
+++ b/github_activity/cli.py
@@ -108,7 +108,7 @@ parser.add_argument(
 
 def main():
     if not _git_installed_check():
-        print("git is required to run github-activity")
+        print("git is required to run github-activity", file=sys.stderr)
         sys.exit(1)
 
     args = parser.parse_args(sys.argv[1:])
@@ -136,7 +136,7 @@ def main():
             os.makedirs(output_dir)
         with open(args.output, "w") as ff:
             ff.write(md)
-        print(f"Finished writing markdown to: {args.output}")
+        print(f"Finished writing markdown to: {args.output}", file=sys.stderr)
     else:
         print(md)
 

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -113,7 +113,7 @@ def get_activity(
         search_query += f" type:{kind}"
 
     # Query for both opened and closed issues/PRs in this window
-    print(f"Running search query:\n{search_query}\n\n")
+    print(f"Running search query:\n{search_query}\n\n", file=sys.stderr)
     query_data = []
     for activity_type in ["created", "closed"]:
         ii_search_query = (


### PR DESCRIPTION
writing only the rendered output to stdout allows piping output to files / pbcopy with minimal editing

I did a previous pass on this in #39. I'm not sure if there's a way to test that no prints to stderr are added? Maybe it would be easier to adopt logging, which also goes to stderr by default and would enable things like log-levels.