### PR TITLE
Handle detection of target from SSH based remotes

### DIFF
--- a/github_activity/cli.py
+++ b/github_activity/cli.py
@@ -3,7 +3,7 @@ import os
 import sys
 from subprocess import run, PIPE
 
-from .github_activity import generate_activity_md
+from .github_activity import generate_activity_md, _parse_target
 from .git import _git_installed_check
 
 DESCRIPTION = "Generate a markdown changelog of GitHub activity within a date window."
@@ -140,7 +140,12 @@ def main():
                 ref = None
             if not ref:
                 raise ValueError(err)
-            args.target = ref.split("/", 3)[-1]
+
+            org, repo = _parse_target(ref)
+            if repo:
+                args.target = f"{org}/{repo}"
+            else:
+                args.target = f"{org}"
         except Exception:
             raise ValueError(err)
 

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -487,8 +487,21 @@ def extract_comments(comments):
 
 
 def _parse_target(target):
+    """
+    Returns (org, repo) based on input such as:
+
+    - executablebooks
+    - executablebooks/jupyter-book
+    - http(s)://github.com/executablebooks
+    - http(s)://github.com/executablebooks/jupyter-book(.git)
+    - git@github.com:executablebooks/jupyter-book(.git)
+    """
     if target.startswith("http"):
         target = target.split("github.com/")[-1]
+    elif "@github.com:" in target:
+        target = target.split("@github.com:")[-1]
+    if target.endswith(".git"):
+        target = target.rsplit(".git", 1)[0]
     parts = target.split("/")
     if len(parts) == 2:
         org, repo = parts


### PR DESCRIPTION
This is a PR to update the working branch of #45 which had an issue to detect the target correctly if `git remote -v` returned a SSH reference like `git@github.com:jupyterhub/kubespawner.git`.