### PR TITLE
pre-commit configured and executed

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+# Ignore style and complexity
+# E: style errors
+# W: style warnings
+# C: complexity
+# F401: module imported but unused
+# F403: import *
+# F811: redefinition of unused `name` from line `N`
+# F841: local variable assigned but never used
+# E402: module level import not at top of file
+# I100: Import statements are in the wrong order
+# I101: Imported names are in the wrong order. Should be
+ignore = E, C, W, F401, F403, F811, F841, E402, I100, I101, D400
+# builtins = ...
+# exclude = ...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,9 @@
 name: continuous-integration
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,49 +3,45 @@ name: continuous-integration
 on: [push, pull_request]
 
 jobs:
-
   tests:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    # Only testing 3.8 to avoid too many github API calls
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[testing]
-    - name: Run tests
-      env:
-        GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: pytest
+      - uses: actions/checkout@v2
+      # Only testing 3.8 to avoid too many github API calls
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[testing]
+      - name: Run tests
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pytest
 
   docs:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[sphinx]
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[sphinx]
 
-    - name: Build docs
-      run: |
-        cd docs
-        make html
+      - name: Build docs
+        run: |
+          cd docs
+          make html
 
   publish:
-
     name: Publish to PyPi
     needs: [tests]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,29 @@ name: continuous-integration
 on: [push, pull_request]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      # ref: https://github.com/pre-commit/action
+      - uses: pre-commit/action@v2.0.3
+      - name: Help message if pre-commit fail
+        if: ${{ failure() }}
+        run: |
+          echo "You can install pre-commit hooks to automatically run formatting"
+          echo "on each commit with:"
+          echo "    pre-commit install"
+          echo "or you can run by hand on staged files with"
+          echo "    pre-commit run"
+          echo "or after-the-fact on already committed files with"
+          echo "    pre-commit run --all-files"
+
   tests:
     runs-on: ubuntu-latest
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# Common tasks
+#
+# - Run on all files:   pre-commit run --all-files
+# - Register git hooks: pre-commit install --install-hooks
+#
+repos:
+  # Autoformat: Python code
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+
+  # Autoformat: markdown, yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.3.0
+    hooks:
+      - id: prettier
+        exclude: tests/.*
+
+  # Autoformat: https://github.com/asottile/reorder_python_imports
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.5.0
+    hooks:
+      - id: reorder-python-imports
+
+  # Misc...
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    # ref: https://github.com/pre-commit/pre-commit-hooks#hooks-available
+    hooks:
+      # Autoformat: Makes sure files end in a newline and only a newline.
+      - id: end-of-file-fixer
+        exclude: tests/.*
+
+      # Autoformat: Sorts entries in requirements.txt.
+      - id: requirements-txt-fixer
+
+      # Lint: Check for files with names that would conflict on a
+      # case-insensitive filesystem like MacOS HFS+ or Windows FAT.
+      - id: check-case-conflict
+
+      # Lint: Checks that non-binary executables have a proper shebang.
+      - id: check-executables-have-shebangs
+
+  # Lint: Python code
+  - repo: https://github.com/pycqa/flake8
+    rev: "3.9.2"
+    hooks:
+      - id: flake8

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,7 @@
+# Read the Docs builds and publish our documentation
+#
+# Config reference: https://docs.readthedocs.io/en/stable/config-file/v2.html
+#
 version: 2
 
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 python:
   version: 3
   install:
-      - method: pip
-        path: .
-        extra_requirements:
-          - sphinx
+    - method: pip
+      path: .
+      extra_requirements:
+        - sphinx

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package does two things:
 2. A CLI to render this activity as markdown, suitable for generating changelogs or
    community updates.
 
-*Note: This is a really young tool so it might change a bit over time.*
+_Note: This is a really young tool so it might change a bit over time._
 
 ## Installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,9 +3,7 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 # -- Path setup --------------------------------------------------------------
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -13,8 +11,6 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
-
 # -- Project information -----------------------------------------------------
 
 project = "GitHub Activity"

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ For repositories that use multiple branches, it may be necessary to filter PRs b
 ### Splitting PRs by tags and prefixes
 
 Often you wish to split your PRs into multiple categories so that they are easier
-to scan and parse. You may also *only* want to keep some PRs (e.g. features, or API
+to scan and parse. You may also _only_ want to keep some PRs (e.g. features, or API
 changes) while excluding others from your changelog.
 
 `github-activity` uses the GitHub tags as well as PR prefixes to automatically
@@ -71,6 +71,7 @@ Below is a list of the supported PR types, as well as the tags / title prefixes
 that will be used to identify the right category.
 
 ```{include} tags_list.txt
+
 ```
 
 ```{tip}
@@ -85,20 +86,20 @@ left-most column above.
 You will quickly hit your API limit unless you use a personal access token. Here are
 instructions to generate and use a GitHub access token for use with `github-activity`.
 
-* Create your own access token. Go to the [new GitHub access token page](https://github.com/settings/tokens/new)
+- Create your own access token. Go to the [new GitHub access token page](https://github.com/settings/tokens/new)
   and follow the instructions. Note that while working with a public repository,
   you don't need to set any scopes on the token you create.
-* When using `github-activity` from the command line, use the `--auth` parameter and pass
+- When using `github-activity` from the command line, use the `--auth` parameter and pass
   in your access token. This is easiest if you set it as an **environment variable**,
   such as `MY_ACCESS_TOKEN`. You can then add it to your call like so:
 
   ```
   github-activity jupyter/notebook --since v2019-09-01 --auth $MY_ACCESS_TOKEN
   ```
-* If you do not explicitly pass an access token to `github-activity`, it will search
+
+- If you do not explicitly pass an access token to `github-activity`, it will search
   for an environment variable called `GITHUB_ACCESS_TOKEN`. If it finds this variable,
   it will use this in the API calls to GitHub.
-
 
 ## How does this tool define contributions in the reports?
 
@@ -108,14 +109,14 @@ a given window of time. There are many ways to define this, and there isn't nece
 
 We try to balance the two extremes of "anybody who shows up is recognized as contributing"
 and "nobody is recognized as contributing". We've chosen a few rules that try to reflect
-sustained engagement in issues/PRs, or contributions in the form of help in *others'* issues
+sustained engagement in issues/PRs, or contributions in the form of help in _others'_ issues
 or contributing code.
 
 Here are the rules we follow for finding a list of contributors within a time window. A
 contributor is anyone who has:
 
-* Had their PR merged in that window
-* Commented on >= 2 issues that weren't theirs
-* Commented >= 6 times on any one issue
+- Had their PR merged in that window
+- Commented on >= 2 issues that weren't theirs
+- Commented >= 6 times on any one issue
 
 We'd love feedback on whether this is a good set of rules to use.

--- a/docs/sample_notebook_activity.md
+++ b/docs/sample_notebook_activity.md
@@ -8,15 +8,17 @@ Below is a sample activity report that was generated with `github-activity`.
 The raw markdown is pasted below.
 
 ## 6.0.0...6.0.1
+
 ([full changelog](https://github.com/jupyter/notebook/compare/6.0.0...6.0.1))
 
-
 ### Merged PRs
-* Attempt to re-establish websocket connection to Gateway [#4777](https://github.com/jupyter/notebook/pull/4777) ([@esevan](https://github.com/esevan))
-* add missing react-dom js to package data [#4772](https://github.com/jupyter/notebook/pull/4772) ([@minrk](https://github.com/minrk))
-* Release 6.0 [#4708](https://github.com/jupyter/notebook/pull/4708) ([@lresende](https://github.com/lresende))
+
+- Attempt to re-establish websocket connection to Gateway [#4777](https://github.com/jupyter/notebook/pull/4777) ([@esevan](https://github.com/esevan))
+- add missing react-dom js to package data [#4772](https://github.com/jupyter/notebook/pull/4772) ([@minrk](https://github.com/minrk))
+- Release 6.0 [#4708](https://github.com/jupyter/notebook/pull/4708) ([@lresende](https://github.com/lresende))
 
 ### Contributors to this release
+
 ([GitHub contributors page for this release](https://github.com/jupyter/notebook/graphs/contributors?from=2019-07-16&to=2019-08-22&type=c))
 
 [@0todd0000](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3A0todd0000+updated%3A2019-07-16..2019-08-22&type=Issues) | [@aarchiba](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Aaarchiba+updated%3A2019-07-16..2019-08-22&type=Issues) | [@adejonghm](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Aadejonghm+updated%3A2019-07-16..2019-08-22&type=Issues) | [@benthayer](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Abenthayer+updated%3A2019-07-16..2019-08-22&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ablink1073+updated%3A2019-07-16..2019-08-22&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3ACarreau+updated%3A2019-07-16..2019-08-22&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Acholdgraf+updated%3A2019-07-16..2019-08-22&type=Issues) | [@esevan](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Aesevan+updated%3A2019-07-16..2019-08-22&type=Issues) | [@Flid](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3AFlid+updated%3A2019-07-16..2019-08-22&type=Issues) | [@gnestor](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Agnestor+updated%3A2019-07-16..2019-08-22&type=Issues) | [@hadim](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ahadim+updated%3A2019-07-16..2019-08-22&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ajasongrout+updated%3A2019-07-16..2019-08-22&type=Issues) | [@johncbowers](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ajohncbowers+updated%3A2019-07-16..2019-08-22&type=Issues) | [@jph00](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ajph00+updated%3A2019-07-16..2019-08-22&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Akevin-bates+updated%3A2019-07-16..2019-08-22&type=Issues) | [@lresende](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Alresende+updated%3A2019-07-16..2019-08-22&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ameeseeksmachine+updated%3A2019-07-16..2019-08-22&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Aminrk+updated%3A2019-07-16..2019-08-22&type=Issues) | [@mpacer](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Ampacer+updated%3A2019-07-16..2019-08-22&type=Issues) | [@parkerwill](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Aparkerwill+updated%3A2019-07-16..2019-08-22&type=Issues) | [@reichenbch](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Areichenbch+updated%3A2019-07-16..2019-08-22&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3ASylvainCorlay+updated%3A2019-07-16..2019-08-22&type=Issues) | [@takluyver](https://github.com/search?q=repo%3Ajupyter%2Fnotebook+involves%3Atakluyver+updated%3A2019-07-16..2019-08-22&type=Issues)

--- a/github_activity/cache.py
+++ b/github_activity/cache.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pandas as pd

--- a/github_activity/cache.py
+++ b/github_activity/cache.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
 
 DEFAULT_PATH_CACHE = Path("~/data_github_activity").expanduser()
 

--- a/github_activity/cli.py
+++ b/github_activity/cli.py
@@ -1,10 +1,12 @@
 import argparse
 import os
 import sys
-from subprocess import run, PIPE
+from subprocess import PIPE
+from subprocess import run
 
-from .github_activity import generate_activity_md, _parse_target
 from .git import _git_installed_check
+from .github_activity import _parse_target
+from .github_activity import generate_activity_md
 
 DESCRIPTION = "Generate a markdown changelog of GitHub activity within a date window."
 parser = argparse.ArgumentParser(description=DESCRIPTION)

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -308,7 +308,11 @@ def generate_activity_md(
     # Initialize our tags with empty metadata
     for key, vals in tags_metadata.items():
         vals.update(
-            {"mask": None, "md": [], "data": None,}
+            {
+                "mask": None,
+                "md": [],
+                "data": None,
+            }
         )
 
     # Separate out items by their tag types

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -1,17 +1,19 @@
 """Use the GraphQL api to grab issues/PRs that match a query."""
 import datetime
-import dateutil
-import pytz
-import requests
 import sys
 import urllib
 from pathlib import Path
-from subprocess import run, PIPE
+from subprocess import PIPE
+from subprocess import run
 
-from .graphql import GitHubGraphQlQuery
-from .cache import _cache_data
-import pandas as pd
+import dateutil
 import numpy as np
+import pandas as pd
+import pytz
+import requests
+
+from .cache import _cache_data
+from .graphql import GitHubGraphQlQuery
 
 
 # The tags and description to use in creating subsets of PRs

--- a/github_activity/graphql.py
+++ b/github_activity/graphql.py
@@ -121,6 +121,7 @@ class GitHubGraphQlQuery:
         # NOTE: This main search query has a type, but the query string also has a type.
         # ref ("search"): https://developer.github.com/v4/query/#connections
         # Collect paginated issues
+        pageInfo = None
         self.issues_and_or_prs = []
         for ii in range(n_pages):
             github_search_query = [

--- a/github_activity/tags.yaml
+++ b/github_activity/tags.yaml
@@ -1,64 +1,64 @@
 api_change:
   description: API and Breaking Changes
   pre:
-  - BREAK
-  - BREAKING
-  - BRK
-  - UPGRADE
+    - BREAK
+    - BREAKING
+    - BRK
+    - UPGRADE
   tags:
-  - api-change
-  - apichange
+    - api-change
+    - apichange
 bug:
   description: Bugs fixed
   pre:
-  - FIX
-  - BUG
+    - FIX
+    - BUG
   tags:
-  - bug
-  - bugfix
-  - bugs
+    - bug
+    - bugfix
+    - bugs
 deprecate:
   description: Deprecated features
   pre:
-  - DEPRECATE
-  - DEPRECATION
-  - DEP
+    - DEPRECATE
+    - DEPRECATION
+    - DEP
   tags:
-  - deprecation
-  - deprecate
+    - deprecation
+    - deprecate
 documentation:
   description: Documentation improvements
   pre:
-  - DOC
-  - DOCS
+    - DOC
+    - DOCS
   tags:
-  - documentation
-  - docs
-  - doc
+    - documentation
+    - docs
+    - doc
 enhancement:
   description: Enhancements made
   pre:
-  - NEW
-  - ENH
-  - ENHANCEMENT
-  - IMPROVE
+    - NEW
+    - ENH
+    - ENHANCEMENT
+    - IMPROVE
   tags:
-  - enhancement
-  - enhancements
+    - enhancement
+    - enhancements
 maintenance:
   description: Maintenance and upkeep improvements
   pre:
-  - MAINT
-  - MNT
+    - MAINT
+    - MNT
   tags:
-  - maintenance
-  - maint
+    - maintenance
+    - maint
 new:
   description: New features added
   pre:
-  - NEW
-  - FEAT
-  - FEATURE
+    - NEW
+    - FEAT
+    - FEATURE
   tags:
-  - feature
-  - new
+    - feature
+    - new

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pandas
-requests
-numpy
-python-dateutil
 markdown
+numpy
+pandas
+python-dateutil
+requests
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
-from setuptools import setup, find_packages
 import os
 import os.path as op
 from glob import glob
 from pathlib import Path
+
+from setuptools import find_packages
+from setuptools import setup
 
 init = Path().joinpath("github_activity", "__init__.py")
 for line in init.read_text().split("\n"):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,11 @@ setup(
     license="BSD",
     packages=find_packages(),
     use_package_data=True,
-    entry_points={"console_scripts": ["github-activity = github_activity.cli:main",]},
+    entry_points={
+        "console_scripts": [
+            "github-activity = github_activity.cli:main",
+        ]
+    },
     install_requires=install_packages,
     extras_require={
         "testing": ["pytest", "pytest-regressions"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
-from subprocess import run
 from pathlib import Path
+from subprocess import run
 
 
 def test_cli(tmpdir, file_regression):


### PR DESCRIPTION
I copied a pre-commit config from kubespawner that is reused across the JupyterHub org to a large extent.

Closes #53 by enforcing style, not by documenting it - @manics what do you think?

## This PR includes two misc commits
- ci: accept workflow_dispatch trigger (run workflow button) (8185a32)
- docs: add config reference link to .readthedocs.yml (81226fa)

## This PR has a flake8 failure still

There was one test failure I didn't fix because I was unsure how to do so. @choldgraf perhaps you can push a commit to this pr fixing this?

```
github_activity/graphql.py:132:60: F821 undefined name 'pageInfo'
```

https://github.com/executablebooks/github-activity/blob/8180a514c8caaac4ebd3abf9236581e2ee70b7f8/github_activity/graphql.py#L131-L132