### PR TITLE
:wrench: MAINT Split test_cli using @pytest.mark.parameterize

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,35 @@
 from pathlib import Path
 from subprocess import run
 
+from pytest import mark
 
-def test_cli(tmpdir, file_regression):
+
+@mark.parametrize(
+    "cmd,basename",
+    [
+        # CLI with URL
+        (
+            "github-activity {url} -s 2019-09-01 -u 2019-11-01 -o {path_output}",
+            "cli_w_url",
+        ),
+        # CLI with parts
+        (
+            "github-activity {org}/{repo} -s 2019-09-01 -u 2019-11-01 -o {path_output}",
+            "cli_w_parts",
+        ),
+        # CLI with default branch
+        (
+            "github-activity {org}/{repo} -s 2019-09-01 -u 2019-11-01 -o {path_output} -b master",
+            "cli_def_branch",
+        ),
+        # CLI with no target
+        (
+            "github-activity -s 2019-09-01 -u 2019-11-01 -o {path_output}",
+            "cli_no_target",
+        ),
+    ],
+)
+def test_cli(tmpdir, file_regression, cmd, basename):
     """The output of all file_regressions should be the same, testing diff opts."""
     path_tmp = Path(tmpdir)
     path_output = path_tmp.joinpath("out.md")
@@ -10,36 +37,23 @@ def test_cli(tmpdir, file_regression):
     url = "https://github.com/executablebooks/github-activity"
     org, repo = ("executablebooks", "github-activity")
 
-    # CLI with URL
-    cmd = f"github-activity {url} -s 2019-09-01 -u 2019-11-01 -o {path_output}"
-    run(cmd.split(), check=True)
+    command = cmd.format(path_output=path_output, url=url, org=org, repo=repo)
+    run(command.split(), check=True)
     md = path_output.read_text()
-    file_regression.check(md, basename="cli_w_url", extension=".md")
+    file_regression.check(md, basename=basename, extension=".md")
 
-    # CLI with parts
-    cmd = f"github-activity {org}/{repo} -s 2019-09-01 -u 2019-11-01 -o {path_output}"
-    run(cmd.split(), check=True)
-    md = path_output.read_text()
-    file_regression.check(md, basename="cli_w_parts", extension=".md")
 
-    # CLI with default branch
-    cmd = f"github-activity {org}/{repo} -s 2019-09-01 -u 2019-11-01 -o {path_output} -b master"
-    run(cmd.split(), check=True)
-    md = path_output.read_text()
-    file_regression.check(md, basename="cli_def_branch", extension=".md")
+def test_cli_nonexistent_branch(tmpdir):
+    path_tmp = Path(tmpdir)
+    path_output = path_tmp.joinpath("out.md")
 
-    # CLI with non-existent branch
+    org, repo = ("executablebooks", "github-activity")
+
     cmd = f"github-activity {org}/{repo} -s 2019-09-01 -u 2019-11-01 -o {path_output} -b foo"
     run(cmd.split(), check=True)
     md = path_output.read_text()
     assert "Contributors to this release" in md
     assert "Merged PRs" not in md
-
-    # CLI with no target
-    cmd = f"github-activity -s 2019-09-01 -u 2019-11-01 -o {path_output}"
-    run(cmd.split(), check=True)
-    md = path_output.read_text()
-    file_regression.check(md, basename="cli_no_target", extension=".md")
 
 
 def test_pr_split(tmpdir, file_regression):


### PR DESCRIPTION
This should make it easier to investigate when one test fails, and also ensures all tests are independent.