### PR TITLE
[ENH] include reviewers and committers in contributor list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -115,8 +115,9 @@ or contributing code.
 Here are the rules we follow for finding a list of contributors within a time window. A
 contributor is anyone who has:
 
-- Had their PR merged in that window
+- Contributed to a PR merged in that window (includes opening, merging, committing, commenting, or committing)
 - Commented on >= 2 issues that weren't theirs
 - Commented >= 6 times on any one issue
+- Known bot accounts are generally not considered contributors
 
 We'd love feedback on whether this is a good set of rules to use.

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -497,7 +497,12 @@ def generate_activity_md(
     gh_contributors_link = f"https://github.com/{org}/{repo}/graphs/contributors?from={data.since_dt:%Y-%m-%d}&to={data.until_dt:%Y-%m-%d}&type=c"
     md += [""]
     md += [f"{extra_head}## Contributors to this release"]
-    md += [""]
+    md += [
+        "",
+        "The following people contributed discussions, new ideas, code and documentation contributions, and review.",
+        "See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).",
+        "",
+    ]
     md += [f"([GitHub contributors page for this release]({gh_contributors_link}))"]
     md += [""]
     md += [contributor_md]

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -56,6 +56,15 @@ TAGS_METADATA_BASE = {
     },
 }
 
+# exclude known bots from contributor lists
+# TODO: configurable? Everybody's got their own bots.
+BOT_USERS = {
+    "dependabot",
+    "meeseeksmachine",
+    "pre-commit-ci",
+    "welcome",
+}
+
 
 def get_activity(
     target, since, until=None, repo=None, kind=None, auth=None, cache=None
@@ -252,7 +261,7 @@ def generate_activity_md(
 
         if row.kind == "pr":
             for committer in row.committers:
-                if committer not in row.committers:
+                if committer not in row.committers and committer not in BOT_USERS:
                     item_contributors.append(committer)
             if row.mergedBy and row.mergedBy != row.author:
                 item_contributors.append(row.mergedBy)
@@ -268,6 +277,9 @@ def generate_activity_md(
                 continue
 
             comment_author = comment_author["login"]
+            if comment_author in BOT_USERS:
+                # ignore bots
+                continue
 
             # Add to list of commentors on items they didn't author
             if comment_author != row["author"]:
@@ -429,6 +441,7 @@ def generate_activity_md(
                     [
                         f"[@{user}](https://github.com/{user})"
                         for user in irowdata.contributors
+                        if user not in BOT_USERS
                     ]
                 )
                 this_md = f"- {ititle} [#{irowdata['number']}]({irowdata['url']}) ({contributor_list})"

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -236,9 +236,31 @@ def generate_activity_md(
     comment_others_cutoff = 2  # Comments on issues somebody else has authored
     comment_helpers = []
     all_contributors = []
-    for _, iitems in data.iterrows():
+    # add column for participants in each issue (not just original author)
+    data["contributors"] = [[]] * len(data)
+    for ix, row in data.iterrows():
         item_commentors = []
-        for icomment in iitems["comments"]["edges"]:
+        item_contributors = []
+
+        # contributor order:
+        # - author
+        # - committers
+        # - merger
+        # - reviewers
+
+        item_contributors.append(row.author)
+
+        if row.kind == "pr":
+            for committer in row.committers:
+                if committer not in row.committers:
+                    item_contributors.append(committer)
+            if row.mergedBy and row.mergedBy != row.author:
+                item_contributors.append(row.mergedBy)
+            for reviewer in row.reviewers:
+                if reviewer not in item_contributors:
+                    item_contributors.append(reviewer)
+
+        for icomment in row["comments"]["edges"]:
             comment_author = icomment["node"]["author"]
             if not comment_author:
                 # This happens if the GitHub user has been deleted
@@ -248,11 +270,15 @@ def generate_activity_md(
             comment_author = comment_author["login"]
 
             # Add to list of commentors on items they didn't author
-            if comment_author != iitems["author"]:
+            if comment_author != row["author"]:
                 comment_helpers.append(comment_author)
 
             # Add to list of commentors for this item so we can see how many times they commented
             item_commentors.append(comment_author)
+
+            # count all comments on a PR as a contributor
+            if comment_author not in item_contributors:
+                item_contributors.append(comment_author)
 
         # Count any commentors that had enough comments on the issue to be a contributor
         item_commentors_counts = pd.value_counts(item_commentors)
@@ -262,16 +288,13 @@ def generate_activity_md(
         for person in item_commentors_counts:
             all_contributors.append(person)
 
+        # record contributor list (ordered, unique)
+        data.at[ix, "contributors"] = item_contributors
+
     comment_contributor_counts = pd.value_counts(comment_helpers)
     all_contributors += comment_contributor_counts[
         comment_contributor_counts >= comment_others_cutoff
     ].index.tolist()
-
-    # Clean up the data a bit
-    data["labels"] = data["labels"].map(
-        lambda a: [edge["node"]["name"] for edge in a["edges"]]
-    )
-    data["kind"] = data["url"].map(lambda a: "issue" if "issues/" in a else "pr")
 
     # Filter the PRs by branch (or ref) if given
     if branch is not None:
@@ -307,8 +330,8 @@ def generate_activity_md(
     # Now remove the *closed* PRs (not merged) for our output list
     closed_prs = closed_prs.query("state != 'CLOSED'")
 
-    # Add any author of a merged PR to our contributors list
-    all_contributors += closed_prs["author"].unique().tolist()
+    # Add any contributors to a merged PR to our contributors list
+    all_contributors += closed_prs["contributors"].explode().unique().tolist()
 
     # Define categories for a few labels
     if tags is None:
@@ -402,7 +425,13 @@ def generate_activity_md(
                 ititle = irowdata["title"]
                 if strip_brackets and ititle.strip().startswith("[") and "]" in ititle:
                     ititle = ititle.split("]", 1)[-1].strip()
-                this_md = f"- {ititle} [#{irowdata['number']}]({irowdata['url']}) ([@{author}](https://github.com/{author}))"
+                contributor_list = ", ".join(
+                    [
+                        f"[@{user}](https://github.com/{user})"
+                        for user in irowdata.contributors
+                    ]
+                )
+                this_md = f"- {ititle} [#{irowdata['number']}]({irowdata['url']}) ({contributor_list})"
                 items["md"].append(this_md)
 
     # Get functional GitHub references: any git reference or master@{YY-mm-dd}

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -63,9 +63,22 @@ TAGS_METADATA_BASE = {
 # exclude known bots from contributor lists
 # TODO: configurable? Everybody's got their own bots.
 BOT_USERS = {
+    "codecov",
+    "codecov-io",
     "dependabot",
+    "github-actions",
+    "henchbot",
+    "jupyterlab-dev-mode",
+    "lgtm-com",
     "meeseeksmachine",
+    "names",
+    "now",
     "pre-commit-ci",
+    "renovate",
+    "review-notebook-app",
+    "support",
+    "stale",
+    "todo",
     "welcome",
 }
 

--- a/tests/test_cli/cli_def_branch.md
+++ b/tests/test_cli/cli_def_branch.md
@@ -4,14 +4,14 @@
 
 ## Merged PRs
 
-- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
+- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf), [@betatim](https://github.com/betatim))
 - updating CLI for new tags [#12](https://github.com/executablebooks/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
 - fixing link to changelog with refs [#11](https://github.com/executablebooks/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
-- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
-- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
-- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
+- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 - adding authentication information [#2](https://github.com/executablebooks/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
-- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
+- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 
 ## Contributors to this release
 

--- a/tests/test_cli/cli_def_branch.md
+++ b/tests/test_cli/cli_def_branch.md
@@ -15,6 +15,9 @@
 
 ## Contributors to this release
 
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
 
 [@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)

--- a/tests/test_cli/cli_no_target.md
+++ b/tests/test_cli/cli_no_target.md
@@ -4,14 +4,14 @@
 
 ## Merged PRs
 
-- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
+- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf), [@betatim](https://github.com/betatim))
 - updating CLI for new tags [#12](https://github.com/executablebooks/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
 - fixing link to changelog with refs [#11](https://github.com/executablebooks/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
-- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
-- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
-- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
+- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 - adding authentication information [#2](https://github.com/executablebooks/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
-- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
+- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 
 ## Contributors to this release
 

--- a/tests/test_cli/cli_no_target.md
+++ b/tests/test_cli/cli_no_target.md
@@ -15,6 +15,9 @@
 
 ## Contributors to this release
 
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
 
 [@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)

--- a/tests/test_cli/cli_w_parts.md
+++ b/tests/test_cli/cli_w_parts.md
@@ -4,14 +4,14 @@
 
 ## Merged PRs
 
-- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
+- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf), [@betatim](https://github.com/betatim))
 - updating CLI for new tags [#12](https://github.com/executablebooks/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
 - fixing link to changelog with refs [#11](https://github.com/executablebooks/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
-- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
-- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
-- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
+- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 - adding authentication information [#2](https://github.com/executablebooks/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
-- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
+- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 
 ## Contributors to this release
 

--- a/tests/test_cli/cli_w_parts.md
+++ b/tests/test_cli/cli_w_parts.md
@@ -15,6 +15,9 @@
 
 ## Contributors to this release
 
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
 
 [@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)

--- a/tests/test_cli/cli_w_url.md
+++ b/tests/test_cli/cli_w_url.md
@@ -4,14 +4,14 @@
 
 ## Merged PRs
 
-- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf))
+- defining contributions [#14](https://github.com/executablebooks/github-activity/pull/14) ([@choldgraf](https://github.com/choldgraf), [@betatim](https://github.com/betatim))
 - updating CLI for new tags [#12](https://github.com/executablebooks/github-activity/pull/12) ([@choldgraf](https://github.com/choldgraf))
 - fixing link to changelog with refs [#11](https://github.com/executablebooks/github-activity/pull/11) ([@choldgraf](https://github.com/choldgraf))
-- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf))
-- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf))
-- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio))
+- adding contributors list [#10](https://github.com/executablebooks/github-activity/pull/10) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- some improvements to `since` and opened issues list [#8](https://github.com/executablebooks/github-activity/pull/8) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- Support git references etc. [#6](https://github.com/executablebooks/github-activity/pull/6) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 - adding authentication information [#2](https://github.com/executablebooks/github-activity/pull/2) ([@choldgraf](https://github.com/choldgraf))
-- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio))
+- Mention the required GITHUB_ACCESS_TOKEN [#1](https://github.com/executablebooks/github-activity/pull/1) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 
 ## Contributors to this release
 

--- a/tests/test_cli/cli_w_url.md
+++ b/tests/test_cli/cli_w_url.md
@@ -15,6 +15,9 @@
 
 ## Contributors to this release
 
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2019-09-01&to=2019-11-01&type=c))
 
 [@betatim](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Abetatim+updated%3A2019-09-01..2019-11-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2019-09-01..2019-11-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2019-09-01..2019-11-01&type=Issues)

--- a/tests/test_cli/test_cli_all.md
+++ b/tests/test_cli/test_cli_all.md
@@ -4,26 +4,29 @@
 
 ### Enhancements made
 
-- Use auth for all usages of requests [#60](https://github.com/executablebooks/github-activity/pull/60) ([@blink1073](https://github.com/blink1073))
-- Handle detection of target from SSH based remotes [#51](https://github.com/executablebooks/github-activity/pull/51) ([@consideRatio](https://github.com/consideRatio))
-- ✨ ENH: Auto-detecting the target [#45](https://github.com/executablebooks/github-activity/pull/45) ([@choldgraf](https://github.com/choldgraf))
+- Use auth for all usages of requests [#60](https://github.com/executablebooks/github-activity/pull/60) ([@blink1073](https://github.com/blink1073), [@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- Handle detection of target from SSH based remotes [#51](https://github.com/executablebooks/github-activity/pull/51) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
+- ✨ ENH: Auto-detecting the target [#45](https://github.com/executablebooks/github-activity/pull/45) ([@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
 
 ### Bugs fixed
 
-- 🐛 FIX: write status messages to sys.stderr [#47](https://github.com/executablebooks/github-activity/pull/47) ([@minrk](https://github.com/minrk))
+- 🐛 FIX: write status messages to sys.stderr [#47](https://github.com/executablebooks/github-activity/pull/47) ([@minrk](https://github.com/minrk), [@choldgraf](https://github.com/choldgraf))
 
 ### Maintenance and upkeep improvements
 
-- 🔧 MAINT: Split test_cli using @pytest.mark.parameterize [#56](https://github.com/executablebooks/github-activity/pull/56) ([@manics](https://github.com/manics))
-- pre-commit configured and executed [#55](https://github.com/executablebooks/github-activity/pull/55) ([@consideRatio](https://github.com/consideRatio))
-- 🔧 MAINT: _get_latest_tag should use the remote repo [#52](https://github.com/executablebooks/github-activity/pull/52) ([@manics](https://github.com/manics))
+- 🔧 MAINT: Split test_cli using @pytest.mark.parameterize [#56](https://github.com/executablebooks/github-activity/pull/56) ([@manics](https://github.com/manics), [@choldgraf](https://github.com/choldgraf))
+- pre-commit configured and executed [#55](https://github.com/executablebooks/github-activity/pull/55) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
+- 🔧 MAINT: _get_latest_tag should use the remote repo [#52](https://github.com/executablebooks/github-activity/pull/52) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - 🔧 MAINT: hyphen instead of asterisk [#44](https://github.com/executablebooks/github-activity/pull/44) ([@choldgraf](https://github.com/choldgraf))
 
 ### Contributors to this release
 
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2021-02-20&to=2021-12-01&type=c))
 
-[@blink1073](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Ablink1073+updated%3A2021-02-20..2021-12-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2021-02-20..2021-12-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2021-02-20..2021-12-01&type=Issues) | [@manics](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Amanics+updated%3A2021-02-20..2021-12-01&type=Issues) | [@minrk](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Aminrk+updated%3A2021-02-20..2021-12-01&type=Issues) | [@welcome](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Awelcome+updated%3A2021-02-20..2021-12-01&type=Issues) | [@wolfv](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Awolfv+updated%3A2021-02-20..2021-12-01&type=Issues)
+[@blink1073](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Ablink1073+updated%3A2021-02-20..2021-12-01&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2021-02-20..2021-12-01&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2021-02-20..2021-12-01&type=Issues) | [@manics](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Amanics+updated%3A2021-02-20..2021-12-01&type=Issues) | [@minrk](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Aminrk+updated%3A2021-02-20..2021-12-01&type=Issues) | [@wolfv](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Awolfv+updated%3A2021-02-20..2021-12-01&type=Issues)
 
 ## v0.1.3
 
@@ -31,16 +34,16 @@
 
 ### New features added
 
-- ✨NEW: heading_level argument for increasing heading level [#38](https://github.com/executablebooks/github-activity/pull/38) ([@minrk](https://github.com/minrk))
+- ✨NEW: heading_level argument for increasing heading level [#38](https://github.com/executablebooks/github-activity/pull/38) ([@minrk](https://github.com/minrk), [@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
 
 ### Enhancements made
 
-- 👌IMPROVE: add blank lines below headings [#36](https://github.com/executablebooks/github-activity/pull/36) ([@minrk](https://github.com/minrk))
-- 👌 IMPROVE: since/until: assume git reference, fallback to datetime [#33](https://github.com/executablebooks/github-activity/pull/33) ([@consideRatio](https://github.com/consideRatio))
+- 👌IMPROVE: add blank lines below headings [#36](https://github.com/executablebooks/github-activity/pull/36) ([@minrk](https://github.com/minrk), [@choldgraf](https://github.com/choldgraf))
+- 👌 IMPROVE: since/until: assume git reference, fallback to datetime [#33](https://github.com/executablebooks/github-activity/pull/33) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 
 ### Bugs fixed
 
-- 🐛 FIX: tags like 'doctor' would trigger 'doc' tag [#40](https://github.com/executablebooks/github-activity/pull/40) ([@consideRatio](https://github.com/consideRatio))
+- 🐛 FIX: tags like 'doctor' would trigger 'doc' tag [#40](https://github.com/executablebooks/github-activity/pull/40) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 
 ### Documentation improvements
 
@@ -48,16 +51,19 @@
 
 ### Other merged PRs
 
-- Adding filtering by branch [#42](https://github.com/executablebooks/github-activity/pull/42) ([@choldgraf](https://github.com/choldgraf))
-- use tqdm for progress [#39](https://github.com/executablebooks/github-activity/pull/39) ([@minrk](https://github.com/minrk))
-- Remove no longer used code [#37](https://github.com/executablebooks/github-activity/pull/37) ([@consideRatio](https://github.com/consideRatio))
-- [FIX,TST] resolve refs when not run from a repo [#35](https://github.com/executablebooks/github-activity/pull/35) ([@minrk](https://github.com/minrk))
+- Adding filtering by branch [#42](https://github.com/executablebooks/github-activity/pull/42) ([@choldgraf](https://github.com/choldgraf), [@blink1073](https://github.com/blink1073), [@consideRatio](https://github.com/consideRatio))
+- use tqdm for progress [#39](https://github.com/executablebooks/github-activity/pull/39) ([@minrk](https://github.com/minrk), [@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
+- Remove no longer used code [#37](https://github.com/executablebooks/github-activity/pull/37) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
+- [FIX,TST] resolve refs when not run from a repo [#35](https://github.com/executablebooks/github-activity/pull/35) ([@minrk](https://github.com/minrk), [@choldgraf](https://github.com/choldgraf), [@consideRatio](https://github.com/consideRatio))
 
 ### Contributors to this release
 
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2020-08-31&to=2021-02-20&type=c))
 
-[@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2020-08-31..2021-02-20&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2020-08-31..2021-02-20&type=Issues) | [@minrk](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Aminrk+updated%3A2020-08-31..2021-02-20&type=Issues) | [@welcome](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Awelcome+updated%3A2020-08-31..2021-02-20&type=Issues)
+[@blink1073](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Ablink1073+updated%3A2020-08-31..2021-02-20&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Acholdgraf+updated%3A2020-08-31..2021-02-20&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3AconsideRatio+updated%3A2020-08-31..2021-02-20&type=Issues) | [@minrk](https://github.com/search?q=repo%3Aexecutablebooks%2Fgithub-activity+involves%3Aminrk+updated%3A2020-08-31..2021-02-20&type=Issues)
 
 ## v0.1.2
 
@@ -68,6 +74,9 @@
 - adding thumbsup to query [#31](https://github.com/executablebooks/github-activity/pull/31) ([@choldgraf](https://github.com/choldgraf))
 
 ### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
 
 ([GitHub contributors page for this release](https://github.com/executablebooks/github-activity/graphs/contributors?from=2020-08-07&to=2020-08-31&type=c))
 

--- a/tests/test_cli/test_pr_split.md
+++ b/tests/test_cli/test_pr_split.md
@@ -4,30 +4,30 @@
 
 ## New features added
 
-- ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/executablebooks/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf))
+- ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/executablebooks/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf), [@codecov](https://github.com/codecov))
 
 ## Enhancements made
 
-- 👌 IMPROVE: improving numbered sections [#826](https://github.com/executablebooks/jupyter-book/pull/826) ([@choldgraf](https://github.com/choldgraf))
-- checking for toc modification time [#772](https://github.com/executablebooks/jupyter-book/pull/772) ([@choldgraf](https://github.com/choldgraf))
-- first pass toc directive [#757](https://github.com/executablebooks/jupyter-book/pull/757) ([@choldgraf](https://github.com/choldgraf))
+- 👌 IMPROVE: improving numbered sections [#826](https://github.com/executablebooks/jupyter-book/pull/826) ([@choldgraf](https://github.com/choldgraf), [@codecov](https://github.com/codecov))
+- checking for toc modification time [#772](https://github.com/executablebooks/jupyter-book/pull/772) ([@choldgraf](https://github.com/choldgraf), [@chrisjsewell](https://github.com/chrisjsewell))
+- first pass toc directive [#757](https://github.com/executablebooks/jupyter-book/pull/757) ([@choldgraf](https://github.com/choldgraf), [@AakashGfude](https://github.com/AakashGfude))
 
 ## Bugs fixed
 
-- Fix typo in content-blocks.md documentation [#811](https://github.com/executablebooks/jupyter-book/pull/811) ([@MaxGhenis](https://github.com/MaxGhenis))
-- [BUG] Using relative instead of absolute links [#747](https://github.com/executablebooks/jupyter-book/pull/747) ([@AakashGfude](https://github.com/AakashGfude))
-- 🐛 FIX: fixing jupytext install/UI links [#737](https://github.com/executablebooks/jupyter-book/pull/737) ([@chrisjsewell](https://github.com/chrisjsewell))
+- Fix typo in content-blocks.md documentation [#811](https://github.com/executablebooks/jupyter-book/pull/811) ([@MaxGhenis](https://github.com/MaxGhenis), [@choldgraf](https://github.com/choldgraf))
+- [BUG] Using relative instead of absolute links [#747](https://github.com/executablebooks/jupyter-book/pull/747) ([@AakashGfude](https://github.com/AakashGfude), [@choldgraf](https://github.com/choldgraf), [@phaustin](https://github.com/phaustin))
+- 🐛 FIX: fixing jupytext install/UI links [#737](https://github.com/executablebooks/jupyter-book/pull/737) ([@chrisjsewell](https://github.com/chrisjsewell), [@choldgraf](https://github.com/choldgraf))
 
 ## Documentation improvements
 
-- 📚 DOC: update gh-pages + ghp-import docs [#814](https://github.com/executablebooks/jupyter-book/pull/814) ([@TomasBeuzen](https://github.com/TomasBeuzen))
+- 📚 DOC: update gh-pages + ghp-import docs [#814](https://github.com/executablebooks/jupyter-book/pull/814) ([@TomasBeuzen](https://github.com/TomasBeuzen), [@choldgraf](https://github.com/choldgraf))
 - 📚 DOC: note about licenses [#806](https://github.com/executablebooks/jupyter-book/pull/806) ([@choldgraf](https://github.com/choldgraf))
-- 📖 DOCS: Fix google analytics instructions [#799](https://github.com/executablebooks/jupyter-book/pull/799) ([@tobydriscoll](https://github.com/tobydriscoll))
-- Change book_path to path_to_book [#773](https://github.com/executablebooks/jupyter-book/pull/773) ([@MaxGhenis](https://github.com/MaxGhenis))
-- GitHub actions example: note about selective build [#771](https://github.com/executablebooks/jupyter-book/pull/771) ([@consideRatio](https://github.com/consideRatio))
+- 📖 DOCS: Fix google analytics instructions [#799](https://github.com/executablebooks/jupyter-book/pull/799) ([@tobydriscoll](https://github.com/tobydriscoll), [@choldgraf](https://github.com/choldgraf))
+- Change book_path to path_to_book [#773](https://github.com/executablebooks/jupyter-book/pull/773) ([@MaxGhenis](https://github.com/MaxGhenis), [@choldgraf](https://github.com/choldgraf))
+- GitHub actions example: note about selective build [#771](https://github.com/executablebooks/jupyter-book/pull/771) ([@consideRatio](https://github.com/consideRatio), [@choldgraf](https://github.com/choldgraf))
 - getting sphinx thebelab to work [#749](https://github.com/executablebooks/jupyter-book/pull/749) ([@choldgraf](https://github.com/choldgraf))
-- Link documentation for adding cell tags in Jupyter from "Hide or remove content" documentation section [#734](https://github.com/executablebooks/jupyter-book/pull/734) ([@MaxGhenis](https://github.com/MaxGhenis))
-- typo fix [#731](https://github.com/executablebooks/jupyter-book/pull/731) ([@MaxGhenis](https://github.com/MaxGhenis))
+- Link documentation for adding cell tags in Jupyter from "Hide or remove content" documentation section [#734](https://github.com/executablebooks/jupyter-book/pull/734) ([@MaxGhenis](https://github.com/MaxGhenis), [@choldgraf](https://github.com/choldgraf))
+- typo fix [#731](https://github.com/executablebooks/jupyter-book/pull/731) ([@MaxGhenis](https://github.com/MaxGhenis), [@choldgraf](https://github.com/choldgraf))
 
 ## Other merged PRs
 

--- a/tests/test_cli/test_pr_split.md
+++ b/tests/test_cli/test_pr_split.md
@@ -4,11 +4,11 @@
 
 ## New features added
 
-- ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/executablebooks/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf), [@codecov](https://github.com/codecov))
+- ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/executablebooks/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf))
 
 ## Enhancements made
 
-- 👌 IMPROVE: improving numbered sections [#826](https://github.com/executablebooks/jupyter-book/pull/826) ([@choldgraf](https://github.com/choldgraf), [@codecov](https://github.com/codecov))
+- 👌 IMPROVE: improving numbered sections [#826](https://github.com/executablebooks/jupyter-book/pull/826) ([@choldgraf](https://github.com/choldgraf))
 - checking for toc modification time [#772](https://github.com/executablebooks/jupyter-book/pull/772) ([@choldgraf](https://github.com/choldgraf), [@chrisjsewell](https://github.com/chrisjsewell))
 - first pass toc directive [#757](https://github.com/executablebooks/jupyter-book/pull/757) ([@choldgraf](https://github.com/choldgraf), [@AakashGfude](https://github.com/AakashGfude))
 


### PR DESCRIPTION
The most important part of this is done: getting the reviewer list and committer list from graphQL into the data.

- reviews, commits, and comments on merged PRs get counted in the 'all contributors' list
- Instead of only listing the PR author, each merged PR lists contributors to the PR in order:
  1. PR author
  2. all (unique) commit authors and committers
  3. who merged the PR
  4. reviewers
  5. commenters
  
  In practice, this means most PRs will have at least 2 names associated - the PR author and the merging maintainer.
- reviewers, committers, and commenters show up in the author list for each merged PR

new columns:

- reviews (raw graph)
- reviewers (unique list of reviewers)
- commits (raw graph)
- committers (ordered, non-unique list of committers)

I also moved creation of a couple derivative columns to the end of graphql from generate_activity_md, since that's where most similar code already is, and they were useful earlier in the code than they had been created.

Draft, because there are some open design questions, and I haven't touched any tests:

- [ ] do we separate 'author' (includes committers) from 'reviewers' (probably includes merged-by) in a visible way? If so, is it useful to distinguish merged-by from reviews?
- [ ] Should PR commenters be included; if so, should thresholds be applied, or is one comment sufficient?
- [ ] options - I think including multiple committers in the author list is strictly an improvement over what we have now with just the PR author. But should including reviewers/merger be behind an option, if so on/off by default, etc.? At what granularity (bool for each merger, reviewer, commenter)?

[sample output](https://gist.github.com/minrk/3c3f7a0dbf0c92b7c466544e50c32bf0) to compare with [jupyterhub 2.1.0](https://jupyterhub.readthedocs.io/en/2.1.0/changelog.html#id1).

closes #62
closes #67