### PR TITLE
BUG: import dateutil.parser

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -11,7 +11,7 @@ from subprocess import PIPE
 from subprocess import run
 from tempfile import TemporaryDirectory
 
-import dateutil
+import dateutil.parser
 import numpy as np
 import pandas as pd
 import pytz


### PR DESCRIPTION
I noticed that `--all` always fails on my repo. I traced it back to the fact that `import dateutil` does not make `dateutil.parser` available. Incidentally, we should probably be more specific as to the kind of errors that we catch here.