### PR TITLE
Fix: ignore case for `pre`

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -25,40 +25,41 @@ from .graphql import GitHubGraphQlQuery
 TAGS_METADATA_BASE = {
     "new": {
         "tags": ["feature", "new"],
-        "pre": ["NEW", "FEAT", "FEATURE"],
+        "pre": ["new", "feat", "feature"],
         "description": "New features added",
     },
     "enhancement": {
         "tags": ["enhancement", "enhancements"],
-        "pre": ["ENH", "ENHANCEMENT", "IMPROVE", "IMP"],
+        "pre": ["enh", "enhancement", "improve", "imp"],
         "description": "Enhancements made",
     },
     "bug": {
         "tags": ["bug", "bugfix", "bugs"],
-        "pre": ["FIX", "BUG"],
+        "pre": ["fix", "bug"],
         "description": "Bugs fixed",
     },
     "maintenance": {
         "tags": ["maintenance", "maint"],
-        "pre": ["MAINT", "MNT"],
+        "pre": ["maint", "mnt"],
         "description": "Maintenance and upkeep improvements",
     },
     "documentation": {
         "tags": ["documentation", "docs", "doc"],
-        "pre": ["DOC", "DOCS"],
+        "pre": ["doc", "docs"],
         "description": "Documentation improvements",
     },
     "api_change": {
         "tags": ["api-change", "apichange"],
-        "pre": ["BREAK", "BREAKING", "BRK", "UPGRADE"],
+        "pre": ["break", "breaking", "brk", "upgrade"],
         "description": "API and Breaking Changes",
     },
     "deprecate": {
         "tags": ["deprecation", "deprecate"],
-        "pre": ["DEPRECATE", "DEPRECATION", "DEP"],
+        "pre": ["deprecate", "deprecation", "dep"],
         "description": "Deprecated features",
     },
 }
+
 
 
 def get_activity(


### PR DESCRIPTION
This PR makes the prefix matching logic ignore the prefix case.

In the long run, it would be nice to support user-overrides for `TAGS_METADATA_BASE` instead of hard-coding to a particular set of prefixes.

I also note that the documentation mentions https://keepachangelog.com/en/1.0.0/ but the prefixes used there seem fairly different to the ones that we are currently using.