### PR TITLE
Add a continuous integration category

### DIFF
--- a/github_activity/cli.py
+++ b/github_activity/cli.py
@@ -64,7 +64,7 @@ parser.add_argument(
         "A list of the tags to use in generating subsets of PRs for the "
         "markdown report. Must be one of:"
         ""
-        "   ['enhancement', 'bugs', 'maintenance', 'documentation', 'api_change']"
+        "   ['api_change', 'new', 'enhancement', 'bug', 'maintenance', 'documentation', 'ci', 'deprecate']"
         ""
         "If None, all of the above tags will be used."
     ),

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -54,6 +54,11 @@ TAGS_METADATA_BASE = {
         "pre": ["DOC", "DOCS"],
         "description": "Documentation improvements",
     },
+    "ci": {
+        "tags": ["ci", "continuous-integration"],
+        "pre": ["CI"],
+        "description": "Continuous integration improvements",
+    },
     "deprecate": {
         "tags": ["deprecation", "deprecate"],
         "pre": ["DEPRECATE", "DEPRECATION", "DEP"],
@@ -240,7 +245,7 @@ def generate_all_activity_md(
         A list of the tags to use in generating subsets of PRs for the markdown report.
         Must be one of:
 
-            ['enhancement', 'bugs', 'maintenance', 'documentation', 'api_change']
+            ['api_change', 'new', 'enhancement', 'bug', 'maintenance', 'documentation', 'ci', 'deprecate']
 
         If None, all of the above tags will be used.
     include_issues : bool
@@ -370,7 +375,7 @@ def generate_activity_md(
         A list of the tags to use in generating subsets of PRs for the markdown report.
         Must be one of:
 
-            ['enhancement', 'bugs', 'maintenance', 'documentation', 'api_change']
+            ['api_change', 'new', 'enhancement', 'bug', 'maintenance', 'documentation', 'ci', 'deprecate']
 
         If None, all of the above tags will be used.
     include_issues : bool


### PR DESCRIPTION
In the jupyterhub organization I've often ended up labelling PRs with a `ci` label and/or prefixed the title with `ci`, to then list such PRs under `Continuous integration improvements`.

I think there is a point of distinguishing this category from the maintenance category, because we quite often need to make changes to .github/workflows/test.yaml or similar, but they are often not relevant to think about like another maintenance PR touching the actual code of the project.

I often find myself reading changelogs list of PRs to find what could possibly have caused a bug I'm observing, but the bugs shouldn't have been caused by a CI change typically, so if they are listed separately that is helpful for example.