### PR TITLE
apply token via auth adapter

### DIFF
--- a/github_activity/auth.py
+++ b/github_activity/auth.py
@@ -1,0 +1,17 @@
+from requests.auth import AuthBase
+
+
+class TokenAuth(AuthBase):
+    """Apply Bearer token auth to request
+
+    Requests doesn't respect Authorization header reliably
+    unless applied via `auth` adapter.
+    """
+
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r):
+        # add token to auth
+        r.headers["Authorization"] = f"Bearer {self.token}"
+        return r

--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -18,6 +18,7 @@ import pandas as pd
 import pytz
 import requests
 
+from .auth import TokenAuth
 from .cache import _cache_data
 from .graphql import GitHubGraphQlQuery
 
@@ -781,11 +782,12 @@ def _get_datetime_and_type(org, repo, datetime_or_git_ref, auth):
             )
 
 
-def _get_datetime_from_git_ref(org, repo, ref, auth):
+def _get_datetime_from_git_ref(org, repo, ref, token):
     """Return a datetime from a git reference."""
-    headers = {"Authorization": "Bearer %s" % auth}
+    auth = TokenAuth(token)
     url = f"https://api.github.com/repos/{org}/{repo}/commits/{ref}"
-    response = requests.get(url, headers=headers)
+    # prevent requests from using netrc
+    response = requests.get(url, auth=auth)
     response.raise_for_status()
     return dateutil.parser.parse(response.json()["commit"]["committer"]["date"])
 


### PR DESCRIPTION
requests [doesn't respect Authorization header](https://github.com/psf/requests/issues/3929) reliably, Auth adapter must be specified to override netrc without specifying `trust_env=False` which disables all kinds of unrelated stuff.

closes #96 (actually, this time)

cc @yuvipanda