### PR TITLE
Fix ReadTheDocs config - specifying conf location is required

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,7 @@
 version: 2
 
 sphinx:
+  configuration: docs/conf.py
   builder: dirhtml
 
 build:


### PR DESCRIPTION
The schema requires specifying this explicitly it seems (https://docs.readthedocs.com/platform/stable/config-file/v2.html#sphinx-configuration).