### PR TITLE
Ensure PRs only show up once per changelog

### DIFF
--- a/docs/use.md
+++ b/docs/use.md
@@ -64,6 +64,10 @@ You can choose to *remove* some types of PRs from your changelog by passing the
 left-most column above.
 ```
 
+### Pull Requests with Multiple Matching Labels
+
+If a pull request has multiple labels that match different categories, it will appear in **only the first matching section** based on the order of categories processed. For example, a PR labeled with both `api-change` and `enhancement` will appear only in the "API and Breaking Changes" section, not in "Enhancements made". The categories are processed in the same order as they show above.
+
 (use:token)=
 
 ## Use a GitHub API token

--- a/tests/test_cli/test_pr_split.md
+++ b/tests/test_cli/test_pr_split.md
@@ -2,13 +2,16 @@
 
 ([full changelog](https://github.com/jupyter-book/jupyter-book/compare/v0.7.1...v0.7.3))
 
+## API and Breaking Changes
+
+- 👌 IMPROVE: improving numbered sections [#826](https://github.com/jupyter-book/jupyter-book/pull/826) ([@choldgraf](https://github.com/choldgraf))
+
 ## New features added
 
 - ✨ NEW: Adding - chapter entries to _toc.yml [#817](https://github.com/jupyter-book/jupyter-book/pull/817) ([@choldgraf](https://github.com/choldgraf))
 
 ## Enhancements made
 
-- 👌 IMPROVE: improving numbered sections [#826](https://github.com/jupyter-book/jupyter-book/pull/826) ([@choldgraf](https://github.com/choldgraf))
 - checking for toc modification time [#772](https://github.com/jupyter-book/jupyter-book/pull/772) ([@choldgraf](https://github.com/choldgraf), [@chrisjsewell](https://github.com/chrisjsewell))
 - first pass toc directive [#757](https://github.com/jupyter-book/jupyter-book/pull/757) ([@choldgraf](https://github.com/choldgraf), [@AakashGfude](https://github.com/AakashGfude))
 


### PR DESCRIPTION
Currently, if a pull request has multiple labels, then it'll show up in multiple sections. This isn't common practice and means that some PRs clutter up the output multiple times.

This PR makes it so that if a PR matches one label, it won't be included in any other sections. It also uses OrderedDict so that we're more confident the label ordering won't change in our logic. This should make the outputs more reliable and streamlined.