### PR TITLE
Add `pytz` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ markdown
 numpy
 pandas
 python-dateutil
+pytz
 requests
 tqdm


### PR DESCRIPTION
`pytz` is currently being imported and used here:

https://github.com/executablebooks/github-activity/blob/7e3a545345a2703bf79a90f7c7b90eb0e3611046/github_activity/github_activity.py#L21

https://github.com/executablebooks/github-activity/blob/7e3a545345a2703bf79a90f7c7b90eb0e3611046/github_activity/github_activity.py#L835

However currently it's not defined as part of the requirements.

And the next version of pandas will make `pytz` an optional dependency: https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html#pytz-now-an-optional-dependency
