### PR TITLE
Handle the case when `ignored_contributors` is `None`

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -467,7 +467,9 @@ def generate_activity_md(
     def ignored_user(username):
         if username in bot_users:
             return True
-        if ignored_contributors and any(fnmatch.fnmatch(username, user) for user in ignored_contributors):
+        if ignored_contributors and any(
+            fnmatch.fnmatch(username, user) for user in ignored_contributors
+        ):
             return True
         return False
 


### PR DESCRIPTION
As noticed in https://github.com/jupyter-server/jupyter_releaser/pull/627#issuecomment-3633604919

It looks like the `None`  case needs to be handled too.