### PR TITLE
Properly handle `branch`, default to `main`

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -690,9 +690,11 @@ def generate_activity_md(
                 this_md = f"- {ititle} [#{irowdata['number']}]({irowdata['url']}) ({contributor_list})"
                 items["md"].append(this_md)
 
-    # Get functional GitHub references: any git reference or master@{YY-mm-dd}
+    # Get functional GitHub references: any git reference or {branch}@{YY-mm-dd}
+    # Use the branch parameter if provided, otherwise default to "main"
+    ref_branch = branch or "main"
     if closed_prs.size > 0 and not data.since_is_git_ref:
-        since = f"master@{{{data.since_dt:%Y-%m-%d}}}"
+        since = f"{ref_branch}@{{{data.since_dt:%Y-%m-%d}}}"
         closest_date_start = closed_prs.loc[
             abs(
                 pd.to_datetime(closed_prs["closedAt"], utc=True)
@@ -704,7 +706,7 @@ def generate_activity_md(
         since_ref = since
 
     if closed_prs.size > 0 and not data.until_is_git_ref:
-        until = f"master@{{{data.until_dt:%Y-%m-%d}}}"
+        until = f"{ref_branch}@{{{data.until_dt:%Y-%m-%d}}}"
         closest_date_stop = closed_prs.loc[
             abs(
                 pd.to_datetime(closed_prs["closedAt"], utc=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ from pytest import mark
         ),
         # CLI with default branch
         (
-            "github-activity {org}/{repo} -s 2021-01-01 -u 2021-01-15 -o {path_output} -b master",
+            "github-activity {org}/{repo} -s 2021-01-01 -u 2021-01-15 -o {path_output} -b main",
             "cli_def_branch",
         ),
         # CLI with no target

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,9 +18,9 @@ from pytest import mark
             "github-activity {org}/{repo} -s 2021-01-01 -u 2021-01-15 -o {path_output}",
             "cli_w_parts",
         ),
-        # CLI with default branch
+        # CLI with explicit branch filter (using master since that was likely the name in 2021)
         (
-            "github-activity {org}/{repo} -s 2021-01-01 -u 2021-01-15 -o {path_output} -b main",
+            "github-activity {org}/{repo} -s 2021-01-01 -u 2021-01-15 -o {path_output} -b master",
             "cli_def_branch",
         ),
         # CLI with no target

--- a/tests/test_cli/cli_def_branch.md
+++ b/tests/test_cli/cli_def_branch.md
@@ -1,4 +1,4 @@
-# main@{2021-01-01}...main@{2021-01-15}
+# master@{2021-01-01}...master@{2021-01-15}
 
 ([full changelog](https://github.com/executablebooks/github-activity/compare/c740a454def057304556675ce7694dc0f2eb6c88...c740a454def057304556675ce7694dc0f2eb6c88))
 

--- a/tests/test_cli/cli_def_branch.md
+++ b/tests/test_cli/cli_def_branch.md
@@ -1,4 +1,4 @@
-# master@{2021-01-01}...master@{2021-01-15}
+# main@{2021-01-01}...main@{2021-01-15}
 
 ([full changelog](https://github.com/executablebooks/github-activity/compare/c740a454def057304556675ce7694dc0f2eb6c88...c740a454def057304556675ce7694dc0f2eb6c88))
 

--- a/tests/test_cli/cli_no_target.md
+++ b/tests/test_cli/cli_no_target.md
@@ -1,4 +1,4 @@
-# master@{2021-01-01}...master@{2021-01-15}
+# main@{2021-01-01}...main@{2021-01-15}
 
 ([full changelog](https://github.com/executablebooks/github-activity/compare/c740a454def057304556675ce7694dc0f2eb6c88...c740a454def057304556675ce7694dc0f2eb6c88))
 

--- a/tests/test_cli/cli_no_target_pyproject.md
+++ b/tests/test_cli/cli_no_target_pyproject.md
@@ -1,4 +1,4 @@
-##### master@{2021-01-01}...master@{2021-01-15}
+##### main@{2021-01-01}...main@{2021-01-15}
 
 ([full changelog](https://github.com/executablebooks/github-activity/compare/c740a454def057304556675ce7694dc0f2eb6c88...c740a454def057304556675ce7694dc0f2eb6c88))
 

--- a/tests/test_cli/cli_w_parts.md
+++ b/tests/test_cli/cli_w_parts.md
@@ -1,4 +1,4 @@
-# master@{2021-01-01}...master@{2021-01-15}
+# main@{2021-01-01}...main@{2021-01-15}
 
 ([full changelog](https://github.com/executablebooks/github-activity/compare/c740a454def057304556675ce7694dc0f2eb6c88...c740a454def057304556675ce7694dc0f2eb6c88))
 

--- a/tests/test_cli/cli_w_url.md
+++ b/tests/test_cli/cli_w_url.md
@@ -1,4 +1,4 @@
-# master@{2021-01-01}...master@{2021-01-15}
+# main@{2021-01-01}...main@{2021-01-15}
 
 ([full changelog](https://github.com/executablebooks/github-activity/compare/c740a454def057304556675ce7694dc0f2eb6c88...c740a454def057304556675ce7694dc0f2eb6c88))
 


### PR DESCRIPTION
It looks like `master` was hardcoded.

Nowadays, GitHub repos default to `main`.