### PR TITLE
Ensure bots propagate through concat

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -216,7 +216,7 @@ def get_activity(
         qu.request()
         query_data.append(qu.data)
         # Collect bot users from each query
-        all_bot_users.update(qu.bot_users)
+        all_bot_users.update(qu.data.attrs.get("bot_users", set()))
 
     query_data = (
         pd.concat(query_data).drop_duplicates(subset=["id"]).reset_index(drop=True)

--- a/github_activity/graphql.py
+++ b/github_activity/graphql.py
@@ -293,9 +293,7 @@ class GitHubGraphQlQuery:
 
         # Create a dataframe of the issues and/or PRs
         self.data = pd.DataFrame(self.issues_and_or_prs)
-        # Store bot users in DataFrame attrs and as instance attribute
         self.data.attrs["bot_users"] = bot_users
-        self.bot_users = bot_users
 
         # Add some extra fields
         def get_login(user):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,3 +141,30 @@ def test_contributor_sorting(tmpdir, file_regression):
     run(cmd.split(), check=True)
     md = path_output.read_text()
     file_regression.check(md, extension=".md")
+
+
+def test_bot_filtering(tmpdir):
+    """Test that bot users are detected and filtered from output."""
+    from github_activity.github_activity import get_activity, generate_activity_md
+
+    # Use jupyter-book/mystmd because it's a small release, and know theres bot activity
+    data = get_activity(
+        target="jupyter-book/mystmd",
+        since="mystmd@1.6.5",
+        until="mystmd@1.6.6",
+    )
+
+    # Verify bot_users attrs exists and was preserved (catches the concat bug)
+    assert "bot_users" in data.attrs, "bot_users should be in DataFrame attrs"
+
+    # Generate markdown and verify no bots appear
+    md = generate_activity_md(
+        target="jupyter-book/mystmd",
+        since="mystmd@1.6.5",
+        until="mystmd@1.6.6",
+    )
+
+    # Ensure changeset-bot is not anywhere in the output
+    assert "changeset-bot" not in md, (
+        "changeset-bot should not appear anywhere in output"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,7 +143,8 @@ def test_contributor_sorting(tmpdir, file_regression):
     file_regression.check(md, extension=".md")
 
 
-def test_bot_filtering(tmpdir):
+@mark.integration
+def test_bot_filtering(file_regression):
     """Test that bot users are detected and filtered from output."""
     from github_activity.github_activity import get_activity, generate_activity_md
 
@@ -157,14 +158,17 @@ def test_bot_filtering(tmpdir):
     # Verify bot_users attrs exists and was preserved (catches the concat bug)
     assert "bot_users" in data.attrs, "bot_users should be in DataFrame attrs"
 
-    # Generate markdown and verify no bots appear
+    # Verify we actually detected some bots
+    assert len(data.attrs["bot_users"]) > 0, (
+        "Should have detected bot users in this release"
+    )
+
+    # Generate markdown and save as regression baseline
     md = generate_activity_md(
         target="jupyter-book/mystmd",
         since="mystmd@1.6.5",
         until="mystmd@1.6.6",
     )
 
-    # Ensure changeset-bot is not anywhere in the output
-    assert "changeset-bot" not in md, (
-        "changeset-bot should not appear anywhere in output"
-    )
+    # Use this regression test to make sure no bots are in the output
+    file_regression.check(md, extension=".md")

--- a/tests/test_cli/test_bot_filtering.md
+++ b/tests/test_cli/test_bot_filtering.md
@@ -1,0 +1,23 @@
+# mystmd@1.6.5...mystmd@1.6.6
+
+([full changelog](https://github.com/jupyter-book/mystmd/compare/mystmd@1.6.5...mystmd@1.6.6))
+
+## Bugs fixed
+
+- Fix execution bug: no need for kernelspec if no executable content [#2454](https://github.com/jupyter-book/mystmd/pull/2454) ([@choldgraf](https://github.com/choldgraf), [@stefanv](https://github.com/stefanv))
+
+## Other merged PRs
+
+- 🚀 Release [#2457](https://github.com/jupyter-book/mystmd/pull/2457) ([@stefanv](https://github.com/stefanv))
+- Pull in latest myst-execute [#2456](https://github.com/jupyter-book/mystmd/pull/2456) ([@stefanv](https://github.com/stefanv))
+- 🚀 Release [#2455](https://github.com/jupyter-book/mystmd/pull/2455) ([@stefanv](https://github.com/stefanv))
+- 🚀 Release [#2416](https://github.com/jupyter-book/mystmd/pull/2416) ([@bsipocz](https://github.com/bsipocz), [@choldgraf](https://github.com/choldgraf), [@stefanv](https://github.com/stefanv))
+
+## Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/jupyter-book/mystmd/graphs/contributors?from=2025-11-18&to=2025-11-19&type=c))
+
+@bsipocz ([activity](https://github.com/search?q=repo%3Ajupyter-book%2Fmystmd+involves%3Absipocz+updated%3A2025-11-18..2025-11-19&type=Issues)) | @choldgraf ([activity](https://github.com/search?q=repo%3Ajupyter-book%2Fmystmd+involves%3Acholdgraf+updated%3A2025-11-18..2025-11-19&type=Issues)) | @jukent ([activity](https://github.com/search?q=repo%3Ajupyter-book%2Fmystmd+involves%3Ajukent+updated%3A2025-11-18..2025-11-19&type=Issues)) | @stefanv ([activity](https://github.com/search?q=repo%3Ajupyter-book%2Fmystmd+involves%3Astefanv+updated%3A2025-11-18..2025-11-19&type=Issues))


### PR DESCRIPTION
I think that this fixes #151 - I believe that the pd.concat was deleting the attrs data we were using to store bot users. I also added a test that should have bots in it so we can properly check this.

