### PR TITLE
Handle a mergedBy NaN value

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -550,7 +550,7 @@ def generate_activity_md(
                 item_contributors.add(committer)
             # Only add merger if they're not a bot and not the author
             if (
-                row.mergedBy
+                pd.notna(row.mergedBy)
                 and row.mergedBy != row.author
                 and not ignored_user(row.mergedBy)
             ):

--- a/github_activity/graphql.py
+++ b/github_activity/graphql.py
@@ -323,7 +323,7 @@ class GitHubGraphQlQuery:
 
         # Add some extra fields
         def get_login(user):
-            return user["login"] if not pd.isna(user) else user
+            return user["login"] if pd.notna(user) else user
 
         self.data["author"] = self.data["author"].map(get_login)
         self.data["mergedBy"] = self.data["mergedBy"].map(get_login)


### PR DESCRIPTION
This avoids a TypeError when retrieving PRs that have not been merged, which was causing a critical error. From where mergedBy is set, it can be a pandas na or it can be a username.

Fixes #164

To reproduce:

```sh
github-activity jupyterlab/jupyterlab --since v4.6.0a1 --kind pr
```

Error:
```
Traceback (most recent call last):
  File "/[snip]/github-activity", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/[snip]/github-activity/github_activity/cli.py", line 234, in main
    md = generate_activity_md(
        args.target,
    ...<3 lines>...
        **common_kwargs,
    )
  File "/[snip]/github-activity/github_activity/github_activity.py", line 594, in generate_activity_md
    data.at[ix, "contributors"] = list(item_contributors)
                                  ~~~~^^^^^^^^^^^^^^^^^^^
  File "/[snip]/github-activity/github_activity/github_activity.py", line 386, in __iter__
    for item in sorted(self.other - {self.author}):
                ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'float' and 'str'
```