### PR TITLE
Default --since to latest GitHub Release's tag instead of publication date

### DIFF
--- a/github_activity/github_activity.py
+++ b/github_activity/github_activity.py
@@ -413,7 +413,7 @@ def generate_activity_md(
         repository will be used. Can also be a URL to a GitHub org or repo.
     since : string | None
         Return issues/PRs with activity since this date or git reference. Can be
-        any string that is parsed with dateutil.parser.parse. If None, the date
+        any string that is parsed with dateutil.parser.parse. If None, the tag
         of the latest release will be used.
     until : string | None
         Return issues/PRs with activity until this date or git reference. Can be
@@ -452,11 +452,11 @@ def generate_activity_md(
     """
     org, repo = _parse_target(target)
 
-    # If no since parameter is given, find the name of the latest release
-    # using the _local_ git repostory
+    # If no since parameter is given, default to the tag of the latest GitHub
+    # release, and otherwise fallback to the latest _local_ git tag.
     # TODO: Check that local repo matches org/repo
     if since is None:
-        since = _get_latest_release_date(org, repo)
+        since = _get_latest_release_tag(org, repo)
 
     # Grab the data according to our query
     data = get_activity(
@@ -951,22 +951,32 @@ def _get_datetime_from_git_ref(org, repo, ref, token):
     return dateutil.parser.parse(response.json()["commit"]["committer"]["date"])
 
 
-def _get_latest_release_date(org, repo):
-    """Return the latest release date for a given repository by querying the local repo."""
-    cmd = ["gh", "release", "view", "-R", f"{org}/{repo}", "--json", "name,publishedAt"]
-    print(f"Auto-detecting latest release date for: {org}/{repo}")
+def _get_latest_release_tag(org, repo):
+    """Return the latest GitHub Release associated tag for a given
+    repository."""
+    cmd = [
+        "gh",
+        "release",
+        "view",
+        "-R",
+        f"{org}/{repo}",
+        "--json",
+        "tagName,name,publishedAt",
+    ]
+    print(f"Auto-detecting latest release tag for: {org}/{repo}")
     print(f"Running command: {' '.join(cmd)}")
     out = run(cmd, stdout=PIPE)
     try:
         json = out.stdout.decode()
         release_data = loads(json)
-        print(
-            f"Using release date for release {release_data['name']} on {release_data['publishedAt']}"
-        )
-        return release_data["publishedAt"]
+        tag = release_data["tagName"]
+        release = release_data["name"]
+        published_at = release_data["publishedAt"]
+        print(f"Using tag {tag} from release {release} published at {published_at}")
+        return tag
     except Exception as e:
-        print(f"Error getting latest release date for {org}/{repo}: {e}")
-        print("Reverting to using latest git tag...")
+        print(f"Error getting latest release tag for {org}/{repo}: {e}")
+        print("Reverting to using latest local git tag...")
         out = run("git describe --tags".split(), stdout=PIPE)
         tag = out.stdout.decode().rsplit("-", 2)[0]
         return tag


### PR DESCRIPTION
With #125 we started relating to the latest GitHub Release, and specifically its associated publication date. The motivation for this was described by @choldgraf as:

> This is more reliable in case the repository is using git tags for things other than releases of the current repo (e.g., if it's a monorepo doing many releases)

I was thinking it could be even better to relate to the GitHub Release's tag because a GitHub Release could be retroactively created for some older tag, and would then incorrectly indicate what is relevant to relate to. So, this is what this PR proposes.

By doing this, we also avoid an error message where the latest GitHub Release's publication date was tested by github-activity as a git reference before being treated as a date.

## Before this PR

```
github-activity --heading-level=3
Auto-detecting latest release date for: sensmetry/sysand
Running command: gh release view -R sensmetry/sysand --json name,publishedAt
Using release date for release v0.0.11 on 2026-04-30T11:14:12Z

!! GitHub error: No commit found for SHA: 2026-04-30T11:14:12Z

Running search query:
repo:sensmetry/sysand


Found 10 items, which will take 1 pages
Found 14 items, which will take 1 pages
### main@{2026-04-30}...main@{2026-05-06}
```

## After this PR

```
github-activity --heading-level=3
Auto-detecting latest release tag for: sensmetry/sysand
Running command: gh release view -R sensmetry/sysand --json name,publishedAt,tagName
Using release tag v0.0.11 for release v0.0.11 published at 2026-04-30T11:14:12Z
Running search query:
repo:sensmetry/sysand

Found 12 items, which will take 1 pages
Found 15 items, which will take 1 pages
### v0.0.11...main@{2026-05-06}
...
```

## AI disclaimer

I've used codex (GPT 5.5) as a tool for verification of my hypothesis of what was going on, and some code changes in this PR. Is there a policy about this within executablebooks to be aware about AI use?