### PR TITLE
maint: use pytest-cov, cleanup docs/requirements.txt, and reduce rate limiting issues in CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v6
 
         with:
-          python-version: 3.13
+          python-version: "3.14"
 
       - name: Build package
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,16 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  # To reduce rate limitation issues, avoid running multiple workflows in
+  # paralell for the same git ref (PR / branch / tag) at the same time by
+  # discarding older in-progress runs in favor of the newest.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
@@ -35,16 +45,16 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     env:
-      # Use TOKEN_READONLY if available (pushed branches), otherwise use GITHUB_TOKEN (PRs)
-      # TOKEN_READONLY is a PAT for @choldgraf that only has read-access to this repo but isn't available in PRs.
-      GITHUB_ACCESS_TOKEN: "${{ secrets.TOKEN_READONLY || github.token }}"
+      GITHUB_ACCESS_TOKEN: "${{ github.token }}"
     strategy:
+      # max-parallel declared to reduce rate limitation issues
+      max-parallel: 1
       matrix:
         include:
           # Only test oldest supported and latest python version to reduce
           # GitHub API calls, as they can get rate limited
-          - python-version: "3.10"
           - python-version: 3.x
+          - python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: "3.14"
 
       # ref: https://github.com/pre-commit/action
       - uses: pre-commit/action@v3.0.1
@@ -54,10 +54,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[testing]
+          pip install -e ".[testing]"
 
       - name: Run tests
-        run: pytest --verbose --color=yes --durations=10
+        run: pytest
 
   docs:
     runs-on: ubuntu-24.04
@@ -66,11 +66,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: "3.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[sphinx]
+          pip install -e ".[sphinx]"
 
       - name: Build docs
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
     env:
       # Use TOKEN_READONLY if available (pushed branches), otherwise use GITHUB_TOKEN (PRs)
       # TOKEN_READONLY is a PAT for @choldgraf that only has read-access to this repo but isn't available in PRs.
-      GITHUB_ACCESS_TOKEN: "${{ secrets.TOKEN_READONLY || secrets.GITHUB_TOKEN }}"
+      GITHUB_ACCESS_TOKEN: "${{ secrets.TOKEN_READONLY || github.token }}"
     strategy:
       matrix:
         include:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ sphinx:
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
 
 python:
   install:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-myst-parser
-sphinx>=5
-sphinx-book-theme>=1
-sphinx-design

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,5 +42,5 @@ def test(session):
     session.install("-e", ".[testing]")
 
     # Run github activity and re-use the posargs
-    cmd = ["pytest", "--verbose", "--durations=10"] + session.posargs
+    cmd = ["pytest"] + session.posargs
     session.run(*cmd)

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,6 @@ nox.options.reuse_existing_virtualenvs = True
 @nox.session
 def changelog(session):
     """Run github activity on this repository with the current repo."""
-    session.install("-r", "requirements.txt")
     session.install("-e", ".")
 
     # Run github activity and re-use the posargs
@@ -18,7 +17,6 @@ def changelog(session):
 def docs(session):
     """Run github activity on this repository with the current repo."""
     session.install("-e", ".[sphinx]")
-    session.install("-r", "docs/requirements.txt")
 
     if "live" in session.posargs:
         session.install("sphinx-autobuild")
@@ -38,7 +36,6 @@ def docs(session):
 @nox.session
 def test(session):
     """Run github activity on this repository with the current repo."""
-    session.install("-r", "requirements.txt")
     session.install("-e", ".[testing]")
 
     # Run github activity and re-use the posargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ Source = "https://github.com/executablebooks/github-activity"
 [project.optional-dependencies]
 testing = [
     "pytest",
+    "pytest-cov",
     "pytest-regressions",
 ]
 sphinx = [
@@ -54,6 +55,24 @@ dependencies = { file = "requirements.txt" }
 # only the file-finder
 fallback_version = "0.0.0"
 
+
+[tool.ruff.lint.per-file-ignores]
+"docs/conf.py" = ["E402"]
+
+
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
+[tool.pytest.ini_options]
+addopts = "--verbose --color=yes --durations=10 --cov=github_activity"
+testpaths = ["tests"]
+
+
+[tool.coverage.run]
+patch = ["subprocess"]
+
+
 [tool.tbump]
 github_url = "https://github.com/executablebooks/github-activity"
 
@@ -82,6 +101,3 @@ search = 'version = "{current_version}"'
 [[tool.tbump.file]]
 src = "github_activity/__init__.py"
 search = '__version__ = "{current_version}"'
-
-[tool.ruff.lint.per-file-ignores]
-"docs/conf.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,10 @@ testing = [
     "pytest-regressions",
 ]
 sphinx = [
-    "sphinx",
     "myst_parser",
-    "sphinx_book_theme",
+    "sphinx>=5",
+    "sphinx-design",
+    "sphinx_book_theme>=1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = ["setuptools>=77", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
+
 [project]
 name = "github_activity"
 description = "Grab recent issue/PR activity from a GitHub repository and render it as markdown."
@@ -34,6 +35,7 @@ sphinx = [
 [project.scripts]
 github-activity = "github_activity.cli:main"
 
+
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
@@ -53,7 +55,6 @@ dependencies = { file = "requirements.txt" }
 fallback_version = "0.0.0"
 
 [tool.tbump]
-# Uncomment this if your project is hosted on GitHub:
 github_url = "https://github.com/executablebooks/github-activity"
 
 [tool.tbump.version]


### PR DESCRIPTION
- We had both the optional sphinx install target side by side with docs/requirements.txt and they had also gone out of sync. With this change, we remove docs/requirements.txt and lean on the pyproject.toml's defined requirements.
- pytest-cov added in order to understand better how much test coverage we had in various files
- bumped python 3.13 environment in ci to 3.14
- removed use of @choldgraf read-only PAT secret
- did some interventions to reduce api rate limiting

## AI disclosure

`codex` and its GPT 5.5 model was used to determine the state of things, and wrote the concurrency / max-parallel parts in the CI. Inline comments are my own, and everything else.